### PR TITLE
Optimize buffer using FPGA SRL16 LUTs

### DIFF
--- a/blocks/buffer/verilog/dii_buffer.sv
+++ b/blocks/buffer/verilog/dii_buffer.sv
@@ -76,20 +76,15 @@ module dii_buffer
 
          assign packet_size = BUF_SIZE + 1 - find_first_one(data_last_shifted);
 
-         always_comb begin
-            //flit_out = dii_flit_assemble(|data_last_buf, data[rp].last, data[rp].data);
-            flit_out.valid = |data_last_buf;
-            flit_out.last = data[rp].last;
-            flit_out.data = data[rp].data;
+         assign flit_out.valid = |data_last_buf;
+         assign flit_out.last = data[rp].last;
+         assign flit_out.data = data[rp].data;
          end
       end else begin // if (FULLPACKET)
          assign packet_size = 0;
-         always_comb begin
-            //flit_out = dii_flit_assemble(reg_out_valid, data[rp].last, data[rp].data);
-            flit_out.valid = reg_out_valid;
-            flit_out.last = data[rp].last;
-            flit_out.data = data[rp].data;
-         end
+         assign flit_out.valid = reg_out_valid;
+         assign flit_out.last = data[rp].last;
+         assign flit_out.data = data[rp].data;
       end
    endgenerate
 

--- a/blocks/buffer/verilog/dii_buffer.sv
+++ b/blocks/buffer/verilog/dii_buffer.sv
@@ -1,113 +1,78 @@
 
 import dii_package::dii_flit;
+import dii_package::dii_flit_assemble;
 
 module dii_buffer
-  #(parameter WIDTH=16,
-    parameter SIZE=4,
-    parameter FULLPACKET=0)
+  #(
+    parameter BUF_SIZE = 4,                     // length of the buffer
+    parameter FULLPACKET = 0
+    )
    (
-    input clk,
-    input rst,
+    input                               clk, rst,
+    output logic [$clog2(BUF_SIZE)-1:0] packet_size,
 
-    output logic [$clog2(SIZE)-1:0] packet_size,
-
-    input dii_flit flit_in,
-    output         flit_in_ready,
-    output dii_flit flit_out,
-    input           flit_out_ready
-    );
-
-   // Signals for fifo
-   logic [WIDTH-1:0] fifo_data [0:SIZE-1]; //actual fifo
-   logic [SIZE-1:0]  fifo_last; //actual fifo
-   logic [WIDTH-1:0] nxt_fifo_data [0:SIZE-1];
-   logic [SIZE-1:0]  nxt_fifo_last;
+    input  dii_flit                     flit_in,
+    output reg                          flit_in_ready,
+    output dii_flit                     flit_out,
+    input                               flit_out_ready
+     );
    
-   reg [SIZE:0]      fifo_write_ptr;
-   
-   logic             pop;
-   logic             push;
-   logic             full_packet;
 
-   logic [SIZE-1:0]   valid;
-   always_comb begin : valid_comb
-      integer i;
-      // Set first element
-      valid[SIZE-1] = fifo_write_ptr[SIZE];
-      for (i = SIZE - 2; i >= 0; i = i - 1) begin
-         valid[i] = fifo_write_ptr[i+1] | valid[i+1];
+   localparam ID_W = $clog2(BUF_SIZE); // the width of the index
+
+   // internal shift register
+   dii_flit [BUF_SIZE-1:0]   data;
+   reg [ID_W:0]              rp; // read pointer
+   logic                     reg_out_valid;  // local output valid
+
+   assign flit_in_ready = (rp != BUF_SIZE - 1) || !reg_out_valid;
+
+   always_ff @(posedge clk)
+     if(rst)
+       reg_out_valid <= 0;
+     else if(flit_in.valid)
+       reg_out_valid <= 1;
+     else if(flit_out_ready && rp == 0)
+       reg_out_valid <= 0;
+
+   always_ff @(posedge clk)
+     if(rst)
+       rp <= 0;
+     else if(flit_in.valid && flit_in_ready && (!flit_out.valid || !flit_out_ready) && reg_out_valid)
+       rp <= rp + 1;
+     else if(flit_out.valid && flit_out_ready && (!flit_in.valid  || !flit_in_ready) && rp != 0)
+       rp <= rp - 1;
+
+   always @(posedge clk)
+     if(flit_in.valid && flit_in_ready)
+       data <= {data, flit_in};
+
+   generate                     // SRL does not allow parallel read
+      if(FULLPACKET) begin
+         logic [BUF_SIZE-1:0] data_last_buf;
+
+         always @(posedge clk)
+           if(rst)
+             data_last_buf <= 0;
+           else if(flit_in.valid && flit_in_ready)
+             data_last_buf <= {data_last_buf, flit_in.last && flit_in.valid};
+
+         // Calculate packet size
+         function int count_first(input logic [BUF_SIZE-1:0] data);
+            int i;
+            for(i=0; i<BUF_SIZE; i++)
+              if(data[i])
+                return i+1;
+         endfunction // count_first
+
+         assign packet_size = count_first(data_last_buf);
+         assign flit_out = dii_flit_assemble(|data_last_buf, data[rp].last, data[rp].data);
+
+      end else begin // if (FULLPACKET)
+         assign packet_size = 0;
+         assign flit_out = dii_flit_assemble(reg_out_valid, data[rp].last, data[rp].data);
       end
-   end
-   
-   assign full_packet = |(fifo_last & valid); 
+   endgenerate
 
-   assign pop = flit_out.valid & flit_out_ready;
-   assign push = flit_in.valid & flit_in_ready;
-
-   assign flit_out.data = fifo_data[0][WIDTH-1:0];
-   assign flit_out.last = fifo_last[0];
-   assign flit_out.valid = !FULLPACKET ? valid[0] : full_packet;
-
-   assign flit_in_ready = !fifo_write_ptr[SIZE];
-
-   always @(posedge clk) begin
-      if (rst) begin
-         fifo_write_ptr <= {{SIZE{1'b0}},1'b1};
-      end else if (push & !pop) begin
-         fifo_write_ptr <= fifo_write_ptr << 1;
-      end else if (!push & pop) begin
-         fifo_write_ptr <= fifo_write_ptr >> 1;
-      end
-   end
-
-   always @(*) begin : shift_register_comb
-      integer i;
-      for (i=0;i<SIZE;i=i+1) begin
-         if (pop) begin
-            if (push & fifo_write_ptr[i+1]) begin
-               nxt_fifo_data[i] = flit_in.data;
-               nxt_fifo_last[i] = flit_in.last;
-            end else if (i<SIZE-1) begin
-               nxt_fifo_data[i] = fifo_data[i+1];
-               nxt_fifo_last[i] = fifo_last[i+1];
-            end else begin
-               nxt_fifo_data[i] = fifo_data[i];
-               nxt_fifo_last[i] = fifo_last[i];
-            end
-         end else if (push & fifo_write_ptr[i]) begin
-            nxt_fifo_data[i] = flit_in.data;
-            nxt_fifo_last[i] = flit_in.last;
-         end else begin
-            nxt_fifo_data[i] = fifo_data[i];
-            nxt_fifo_last[i] = fifo_last[i];
-         end
-      end
-   end
-
-   always @(posedge clk) begin : shift_register_seq
-      integer i;
-      for (i=0;i<SIZE;i=i+1) begin
-         fifo_data[i] <= nxt_fifo_data[i];
-         fifo_last[i] <= nxt_fifo_last[i];
-      end
-   end
-
-   // Calculate packet size
-   always @(*) begin: find_first_one
-      integer i;
-      integer not_done;
-      not_done = 1;
-      packet_size = 1;
-
-      for (i=1; i< SIZE; i = i+1) begin
-         if (not_done == 1) begin
-            if (fifo_last[i-1] && valid[i-1]) begin
-               not_done = 0;
-               packet_size = i;
-            end
-         end
-      end
-   end // block: find_first_one
-   
 endmodule // dii_buffer
 

--- a/blocks/buffer/verilog/dii_buffer.sv
+++ b/blocks/buffer/verilog/dii_buffer.sv
@@ -11,7 +11,7 @@ module dii_buffer
     output logic [$clog2(BUF_SIZE):0]   packet_size,
 
     input  dii_flit                     flit_in,
-    output reg                          flit_in_ready,
+    output                              flit_in_ready,
     output dii_flit                     flit_out,
     input                               flit_out_ready
      );

--- a/blocks/buffer/verilog/dii_buffer.sv
+++ b/blocks/buffer/verilog/dii_buffer.sv
@@ -75,16 +75,18 @@ module dii_buffer
          endfunction // size_count
 
          assign packet_size = BUF_SIZE + 1 - find_first_one(data_last_shifted);
-
-         assign flit_out.valid = |data_last_buf;
-         assign flit_out.last = data[rp].last;
-         assign flit_out.data = data[rp].data;
+         always_comb begin
+            flit_out.valid = |data_last_buf;
+            flit_out.last = data[rp].last;
+            flit_out.data = data[rp].data;
          end
       end else begin // if (FULLPACKET)
          assign packet_size = 0;
-         assign flit_out.valid = reg_out_valid;
-         assign flit_out.last = data[rp].last;
-         assign flit_out.data = data[rp].data;
+         always_comb begin
+            flit_out.valid = reg_out_valid;
+            flit_out.last = data[rp].last;
+            flit_out.data = data[rp].data;
+         end
       end
    endgenerate
 

--- a/blocks/statctrlif/verilog/osd_statctrlif.sv
+++ b/blocks/statctrlif/verilog/osd_statctrlif.sv
@@ -1,5 +1,6 @@
 
 import dii_package::dii_flit;
+import dii_package::dii_flit_assemble;
 
 module osd_statctrlif
   #(parameter MODID = 'x,
@@ -42,9 +43,12 @@ module osd_statctrlif
    assign stall = CAN_STALL ? mod_cs_stall : 0;
    
    // State machine
-   reg [3:0]    state;
-   reg [3:0]    nxt_state;
-
+   enum {
+         STATE_IDLE, STATE_START, STATE_ADDR, STATE_WRITE,
+         STATE_RESP_START, STATE_RESP_SRC, STATE_RESP_VALUE,
+         STATE_DROP, STATE_EXT_START, STATE_EXT_WAIT
+         } state, nxt_state;
+        
    // Local request/response data
    reg                      req_write;
    reg                      req_burst;
@@ -70,17 +74,6 @@ module osd_statctrlif
    assign reg_addr = req_addr;
    assign reg_size = req_size;
    assign reg_wdata = reqresp_value;
-   
-   localparam STATE_IDLE       = 0;
-   localparam STATE_START      = 1;
-   localparam STATE_ADDR       = 2;
-   localparam STATE_WRITE      = 3;
-   localparam STATE_RESP_START = 4;
-   localparam STATE_RESP_SRC   = 5;
-   localparam STATE_RESP_VALUE = 6;
-   localparam STATE_DROP       = 7;
-   localparam STATE_EXT_START  = 8;
-   localparam STATE_EXT_WAIT   = 9;
    
    always @(posedge clk) begin
       if (rst) begin
@@ -113,9 +106,7 @@ module osd_statctrlif
       nxt_mod_cs_stall = mod_cs_stall;
       
       debug_in_ready = 0;
-      debug_out.valid = 0;
-      debug_out.data = 0;
-      debug_out.last = 0;
+      debug_out = dii_flit_assemble(0, 0, 0);
 
       reg_request = 0;
       

--- a/blocks/statctrlif/verilog/osd_statctrlif.sv
+++ b/blocks/statctrlif/verilog/osd_statctrlif.sv
@@ -1,6 +1,5 @@
 
 import dii_package::dii_flit;
-import dii_package::dii_flit_assemble;
 
 module osd_statctrlif
   #(parameter MODID = 'x,
@@ -106,7 +105,7 @@ module osd_statctrlif
       nxt_mod_cs_stall = mod_cs_stall;
       
       debug_in_ready = 0;
-      debug_out = dii_flit_assemble(0, 0, 0);
+      debug_out = 0;
 
       reg_request = 0;
       

--- a/interconnect/verilog/ring_router.sv
+++ b/interconnect/verilog/ring_router.sv
@@ -65,7 +65,7 @@ module ring_router
                  );
 
    dii_buffer
-     #(.WIDTH(16), .SIZE(BUFFER_SIZE))
+     #(.BUF_SIZE(BUFFER_SIZE))
    u_buffer0(.*,
              .packet_size       (                  ),
              .flit_in           ( ring_muxed       ),
@@ -75,7 +75,7 @@ module ring_router
              );
 
    dii_buffer
-     #(.WIDTH(16), .SIZE(BUFFER_SIZE))
+     #(.BUF_SIZE(BUFFER_SIZE))
    u_buffer1(.*,
              .packet_size       (                  ),
              .flit_in           ( ring_fwd1        ),

--- a/interfaces/verilog/dii_channel.sv
+++ b/interfaces/verilog/dii_channel.sv
@@ -7,5 +7,16 @@ package dii_package;
       logic [15:0] data;
    } dii_flit;
 
+   function dii_flit
+     dii_flit_assemble(
+                       logic m_valid,
+                       logic m_last,
+                       logic m_data
+                       );
+      dii_flit_assemble.valid = m_valid;
+      dii_flit_assemble.last = m_last;
+      dii_flit_assemble.data = m_data;
+   endfunction // dii_flit_assemble
+
 endpackage // dii_package
 

--- a/interfaces/verilog/dii_channel.sv
+++ b/interfaces/verilog/dii_channel.sv
@@ -7,16 +7,5 @@ package dii_package;
       logic [15:0] data;
    } dii_flit;
 
-   function dii_flit
-     dii_flit_assemble(
-                       logic m_valid,
-                       logic m_last,
-                       logic m_data
-                       );
-      dii_flit_assemble.valid = m_valid;
-      dii_flit_assemble.last = m_last;
-      dii_flit_assemble.data = m_data;
-   endfunction // dii_flit_assemble
-
 endpackage // dii_package
 

--- a/modules/him/verilog/osd_him.sv
+++ b/modules/him/verilog/osd_him.sv
@@ -82,7 +82,7 @@ module osd_him
    end
    
    dii_buffer
-     #(.SIZE(BUF_SIZE), .FULLPACKET(1))
+     #(.BUF_SIZE(BUF_SIZE), .FULLPACKET(1))
    u_egress_buffer(.*,
                    .packet_size (egress_packet_size),
                    .flit_in (dii_in),

--- a/modules/him/verilog/osd_him.sv
+++ b/modules/him/verilog/osd_him.sv
@@ -46,7 +46,7 @@ module osd_him
    end
 
    dii_flit dii_egress;
-   logic    fii_egress_ready;
+   logic    dii_egress_ready;
    logic [$clog2(BUF_SIZE)-1:0] egress_packet_size;
 
    logic       egress_active;


### PR DESCRIPTION
rewrite the buffer to utilize FPGA SRL16 LUTs.
The optimization reduces the area of buffer in him from (149LUT+145Reg) to (64LUT+13Reg).