### PR TITLE
Fixed write_data_reg width to be of DATA_WIDTH

### DIFF
--- a/modules/mam/common/osd_mam.sv
+++ b/modules/mam/common/osd_mam.sv
@@ -154,7 +154,7 @@ module osd_mam
    logic [ADDR_WIDTH-1:0]            nxt_req_addr;
    logic [DATA_WIDTH/8-1:0]          nxt_write_strb;
 
-   reg                               write_data_reg;
+   reg   [DATA_WIDTH-1:0]            write_data_reg;
    logic [DATA_WIDTH-1:0]            nxt_write_data_reg;
 
    // This is the number of (16 bit) words needed to form an address


### PR DESCRIPTION
Newly introduced write_data_reg to remove stop-and-go behavior of MAM accidentally was a single bit. Needs to be of DATA_WIDTH.