### PR TITLE
Add FuseSoC core files for basic modules

### DIFF
--- a/blocks/buffer/buffer.core
+++ b/blocks/buffer/buffer.core
@@ -1,0 +1,13 @@
+CAPI=1
+[main]
+name = opensocdebug:blocks:buffer
+
+depend = 
+   opensocdebug:interfaces:dii_channel
+
+[fileset src_files]
+file_type = verilogSource
+usage = sim synth
+files =
+  common/dii_buffer.sv
+  common/osd_fifo.sv

--- a/blocks/regaccess/regaccess.core
+++ b/blocks/regaccess/regaccess.core
@@ -1,0 +1,16 @@
+CAPI=1
+[main]
+name = opensocdebug:blocks:regaccess
+
+depend =
+  opensocdebug:interfaces:dii_channel
+  opensocdebug:interconnect:debug_ring
+
+[fileset src_files]
+file_type = verilogSource
+usage = sim synth
+files =
+  common/osd_regaccess.sv
+  common/osd_regaccess_layer.sv
+  common/osd_regaccess_demux.sv
+ 

--- a/blocks/timestamp/timestamp.core
+++ b/blocks/timestamp/timestamp.core
@@ -1,0 +1,12 @@
+CAPI=1
+[main]
+name = opensocdebug:blocks:timestamp
+
+depend = 
+   opensocdebug:interfaces:dii_channel
+
+[fileset src_files]
+file_type = verilogSource
+usage = sim synth
+files =
+  common/osd_timestamp.sv

--- a/interconnect/debug_ring.core
+++ b/interconnect/debug_ring.core
@@ -1,0 +1,18 @@
+CAPI=1
+[main]
+name = opensocdebug:interconnect:debug_ring
+
+depend = 
+  opensocdebug:interfaces:dii_channel
+
+[fileset src_files]
+file_type = verilogSource
+usage = sim synth
+files =
+  common/debug_ring.sv
+  common/debug_ring_expand.sv
+  common/ring_router_demux.sv
+  common/ring_router.sv
+  common/ring_router_mux.sv
+  common/ring_router_mux_rr.sv
+  

--- a/interfaces/dii_channel.core
+++ b/interfaces/dii_channel.core
@@ -1,0 +1,11 @@
+CAPI=1
+[main]
+name = opensocdebug:interfaces:dii_channel
+
+[fileset src_files]
+file_type = verilogSource
+usage = sim synth
+files =
+  common/dii_channel.sv
+  common/dii_channel_flat.sv
+

--- a/modules/him/him.core
+++ b/modules/him/him.core
@@ -1,0 +1,11 @@
+CAPI=1
+[main]
+name = opensocdebug:modules:him
+depend =
+  opensocdebug:blocks:buffer
+
+[fileset src_files]
+file_type = verilogSource
+usage = sim synth
+files =
+  common/osd_him.sv

--- a/modules/scm/scm.core
+++ b/modules/scm/scm.core
@@ -1,0 +1,12 @@
+CAPI=1
+[main]
+name = opensocdebug:modules:scm
+depend =
+  opensocdebug:blocks:buffer
+  opensocdebug:blocks:regaccess
+
+[fileset src_files]
+file_type = verilogSource
+usage = sim synth
+files =
+  common/osd_scm.sv


### PR DESCRIPTION
Since the fusesoc cores work great for OpTiMSoC, I think we're ready to merge them as experimental fusesoc support in master. Any objections? @wallento @wsong83 