### PR TITLE
allow set the endianness of mam

### DIFF
--- a/modules/mam/common/osd_mam.sv
+++ b/modules/mam/common/osd_mam.sv
@@ -77,8 +77,8 @@ module osd_mam
    endfunction // endian_conv
 
    logic [DATA_WIDTH-1:0] read_data_m, write_data_m;
-   assign read_data_m = ENDIAN ? endian_conv(read_data)    : read_data;
-   assign write_data  = ENDIAN ? endian_conv(write_data_m) : write_data_m;
+   assign read_data_m = ENDIAN ? read_data    : endian_conv(read_data);
+   assign write_data  = ENDIAN ? write_data_m : endian_conv(write_data_m);
 
    logic        reg_request;
    logic        reg_write;

--- a/modules/mam/common/osd_mam.sv
+++ b/modules/mam/common/osd_mam.sv
@@ -310,9 +310,7 @@ module osd_mam
         end
         STATE_WRITE: begin
            nxt_write_data_reg[(DATA_WIDTH/16-wcounter)*16-1 -: 16] = dp_in.data;
-           write_data[(DATA_WIDTH/16-wcounter)*16-1 -: 16] = dp_in.data;
-           //nxt_write_data_reg[(wcounter+1)*16-1 -: 16] = dp_in.data;
-           //write_data[(wcounter+1)*16-1 -: 16] = dp_in.data;
+           write_data_m[(DATA_WIDTH/16-wcounter)*16-1 -: 16] = dp_in.data;
            dp_in_ready = 1;
            if (dp_in.valid) begin
               nxt_wcounter = wcounter + 1;


### PR DESCRIPTION
This would remove the manual endian conversion in lowRISC top connection.