### PR TITLE
Fix wrong assignment in MAM

### DIFF
--- a/modules/mam/common/osd_mam.sv
+++ b/modules/mam/common/osd_mam.sv
@@ -355,7 +355,7 @@ module osd_mam
         end // case: STATE_WRITE_WAIT
         STATE_WRITE_SINGLE: begin
            nxt_write_data_reg[(DATA_WIDTH/16-wcounter)*16-1 -: 16] = dp_in.data;
-           write_data[(DATA_WIDTH/16-wcounter)*16-1 -: 16] = dp_in.data;
+           write_data_m[(DATA_WIDTH/16-wcounter)*16-1 -: 16] = dp_in.data;
            dp_in_ready = 1;
            if (dp_in.valid) begin
               nxt_wcounter = wcounter + 1;


### PR DESCRIPTION
Oversight from the recent endianness-conversion changes, causes DRC
errors in Vivado synthesis.