### PR TITLE
MAM: Add synchronous flag

### DIFF
--- a/modules/mam/common/osd_mam.sv
+++ b/modules/mam/common/osd_mam.sv
@@ -428,7 +428,7 @@ module osd_mam
               dp_out.data = 16'h0;
            end else begin
               dp_out.data = { 2'b01, 4'b1111, id };
-	      dp_out.last = 1;
+              dp_out.last = 1;
            end
            if (dp_out_ready) begin
               nxt_counter = counter + 1;

--- a/modules/mam/doc/specification.md
+++ b/modules/mam/doc/specification.md
@@ -62,7 +62,7 @@ The sequence starts with a common header:
 
  Payload | Content
  ------- | -------
- 0       | `[15]`: R/W, `[14]`: Single/Chunk, `[13:0]`: Strobe/Chunk size
+ 0       | `[15]`: R/W, `[14]`: Single/Chunk, `[13]`: Synchronous, `[12:0]`: Strobe/Chunk size
  1       | `Address[WIDTH-1:WIDTH-16]`
  ..      | ..
  N       | `Address[15:0]`
@@ -77,8 +77,9 @@ The bits in the first transfer are defined as:
  ------ | -------
  `15`   | R: `0`, W: `1`
  `14`   | Single word access: `0`, Chunk access: `1`
- `13:0` | Chunk: the burst size in number of words,
- `13:0` | Single: byte strobe
+ `13`   | Synchronous write: `1`, asynchronous write: `0`
+ `12:0` | Chunk: the burst size in number of words,
+ `12:0` | Single: byte strobe
 
 TODO: Byte strobe definition
 
@@ -86,6 +87,9 @@ Following this setup information, the actual transfer takes place be
 sending the data in a stream, meaning the debug packets are maximally
 filled and the data spans multiple packets. It is only possible to
 have one read or one write access at a time.
+
+If synchronous mode is selected, a ACK packet is sent after the last word has
+been written. An ACK packet is equal to a read packet with no content.
 
 ## Write Sequence
 

--- a/modules/mam/wishbone/osd_mam_wb.sv
+++ b/modules/mam/wishbone/osd_mam_wb.sv
@@ -74,7 +74,7 @@ module osd_mam_wb
    logic [DATA_WIDTH-1:0]       write_data;
    logic [DATA_WIDTH/8-1:0]     write_strb;
    logic                        write_ready;
-   logic 			write_complete;
+   logic                        write_complete;
 
    logic                        read_valid;
    logic [DATA_WIDTH-1:0]       read_data;

--- a/modules/mam/wishbone/osd_mam_wb.sv
+++ b/modules/mam/wishbone/osd_mam_wb.sv
@@ -68,11 +68,13 @@ module osd_mam_wb
    logic [ADDR_WIDTH-1:0]       req_addr;
    logic                        req_burst;
    logic [13:0]                 req_beats;
+   logic                        req_sync;
 
    logic                        write_valid;
    logic [DATA_WIDTH-1:0]       write_data;
    logic [DATA_WIDTH/8-1:0]     write_strb;
    logic                        write_ready;
+   logic 			write_complete;
 
    logic                        read_valid;
    logic [DATA_WIDTH-1:0]       read_data;
@@ -92,6 +94,8 @@ module osd_mam_wb
    u_mam(.*,
          .clk(clk_i),
          .rst(rst_i));
+
+   assign write_complete = 1'b1;
 
    osd_mam_wb_if
      #(.DATA_WIDTH(DATA_WIDTH), .ADDR_WIDTH(ADDR_WIDTH))


### PR DESCRIPTION
This adds a synchronous access flag. It shrinks the maximum burst size
to 2^12. When the sync flag is set, the MAM issues req_sync with the
start of the burst. When the burst is complete it waits until the bus
interface asserts write_complete.

Currently the write_complete is tied to 1 for wishbone, because we
essentially only need a packet at the very end of the last burst to
confirm the anticipated completion of all writes. The later full
implementations should actually make sure that all outstanding writes
have completed. But for now the roundtrip time (the software block
until it receives the package) should be more than sufficient.