### PR TITLE
Interconnect: Add gateway router

### DIFF
--- a/interconnect/common/debug_ring.sv
+++ b/interconnect/common/debug_ring.sv
@@ -19,7 +19,9 @@ import dii_package::dii_flit;
 
 module debug_ring
   #(parameter PORTS = 1,
-    parameter BUFFER_SIZE = 4)
+    parameter BUFFER_SIZE = 4,
+    parameter SUBNET_BITS = 6,
+    parameter LOCAL_SUBNET = 0)
    (input clk, rst,
     input  [PORTS-1:0][15:0] id_map,
     input  dii_flit [PORTS-1:0] dii_in, output [PORTS-1:0] dii_in_ready,

--- a/interconnect/common/ring_router_gateway.sv
+++ b/interconnect/common/ring_router_gateway.sv
@@ -1,0 +1,135 @@
+// Copyright 2016 by the authors
+//
+// Copyright and related rights are licensed under the Solderpad
+// Hardware License, Version 0.51 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a
+// copy of the License at http://solderpad.org/licenses/SHL-0.51.
+// Unless required by applicable law or agreed to in writing,
+// software, hardware and materials distributed under this License is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the
+// License.
+//
+// Authors:
+//    Philipp Wagner <philipp.wagner@tum.de>
+//    Stefan Wallentowitz <stefan@wallentowitz.de>
+
+import dii_package::dii_flit;
+
+/**
+ * Ring NoC Router with gateway functionality
+ *
+ * This module has similar functionality as the ring_router module, but adds
+ * an additional port "ext". On this port all traffic to subnets outside of the
+ * LOCAL_SUBNET are forwarded.
+ */
+module ring_router_gateway
+   #(
+      parameter BUFFER_SIZE = 4,
+      parameter SUBNET_BITS = 6,
+      parameter LOCAL_SUBNET = 0
+   )(
+      input         clk, rst,
+
+      input [15:0]   id,
+
+      input dii_flit   ring_in0, output ring_in0_ready,
+      input dii_flit   ring_in1, output ring_in1_ready,
+
+      output dii_flit   ring_out0, input ring_out0_ready,
+      output dii_flit   ring_out1, input ring_out1_ready,
+
+      input dii_flit   local_in, output local_in_ready,
+      output dii_flit   local_out, input local_out_ready,
+
+      input dii_flit   ext_in, output ext_in_ready,
+      output dii_flit   ext_out, input ext_out_ready
+   );
+
+   dii_flit ring_fwd0; logic ring_fwd0_ready;
+   dii_flit ring_fwd1; logic ring_fwd1_ready;
+   dii_flit ring_local0; logic ring_local0_ready;
+   dii_flit ring_local1; logic ring_local1_ready;
+   dii_flit ring_ext0; logic ring_ext0_ready;
+   dii_flit ring_ext1; logic ring_ext1_ready;
+   dii_flit ring_muxed; logic ring_muxed_ready;
+
+   ring_router_gateway_demux
+     u_demux0(.*,
+              .in_ring         ( ring_in0          ),
+              .in_ring_ready   ( ring_in0_ready    ),
+              .out_local       ( ring_local0       ),
+              .out_local_ready ( ring_local0_ready ),
+              .out_ring        ( ring_fwd0         ),
+              .out_ring_ready  ( ring_fwd0_ready   ),
+              .out_ext         ( ring_ext0         ),
+              .out_ext_ready   ( ring_ext0_ready   )
+              );
+
+   ring_router_gateway_demux
+     u_demux1(.*,
+              .in_ring         ( ring_in1          ),
+              .in_ring_ready   ( ring_in1_ready    ),
+              .out_local       ( ring_local1       ),
+              .out_local_ready ( ring_local1_ready ),
+              .out_ring        ( ring_fwd1         ),
+              .out_ring_ready  ( ring_fwd1_ready   ),
+              .out_ext         ( ring_ext1         ),
+              .out_ext_ready   ( ring_ext1_ready   )
+              );
+
+   ring_router_mux_rr
+     u_mux_local(.*,
+                 .in0           ( ring_local0       ),
+                 .in0_ready     ( ring_local0_ready ),
+                 .in1           ( ring_local1       ),
+                 .in1_ready     ( ring_local1_ready ),
+                 .out_mux       ( local_out         ),
+                 .out_mux_ready ( local_out_ready   )
+                 );
+
+
+   ring_router_mux_rr
+     u_mux_ext(.*,
+               .in0           ( ring_ext0         ),
+               .in0_ready     ( ring_ext0_ready   ),
+               .in1           ( ring_ext1         ),
+               .in1_ready     ( ring_ext1_ready   ),
+               .out_mux       ( ext_out           ),
+               .out_mux_ready ( ext_out_ready     )
+               );
+
+   ring_router_gateway_mux
+     u_mux_ring0(.*,
+                 .in_ring        ( ring_fwd0        ),
+                 .in_ring_ready  ( ring_fwd0_ready  ),
+                 .in_local       ( local_in         ),
+                 .in_local_ready ( local_in_ready   ),
+                 .in_ext         ( ext_in           ),
+                 .in_ext_ready   ( ext_in_ready     ),
+                 .out_mux        ( ring_muxed       ),
+                 .out_mux_ready  ( ring_muxed_ready )
+                 );
+
+   dii_buffer
+     #(.BUF_SIZE(BUFFER_SIZE))
+   u_buffer0(.*,
+             .packet_size       (                  ),
+             .flit_in           ( ring_muxed       ),
+             .flit_in_ready     ( ring_muxed_ready ),
+             .flit_out          ( ring_out0        ),
+             .flit_out_ready    ( ring_out0_ready  )
+             );
+
+   dii_buffer
+     #(.BUF_SIZE(BUFFER_SIZE))
+   u_buffer1(.*,
+             .packet_size       (                  ),
+             .flit_in           ( ring_fwd1        ),
+             .flit_in_ready     ( ring_fwd1_ready  ),
+             .flit_out          ( ring_out1        ),
+             .flit_out_ready    ( ring_out1_ready  )
+             );
+
+endmodule

--- a/interconnect/common/ring_router_gateway_demux.sv
+++ b/interconnect/common/ring_router_gateway_demux.sv
@@ -1,0 +1,93 @@
+// Copyright 2016 by the authors
+//
+// Copyright and related rights are licensed under the Solderpad
+// Hardware License, Version 0.51 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a
+// copy of the License at http://solderpad.org/licenses/SHL-0.51.
+// Unless required by applicable law or agreed to in writing,
+// software, hardware and materials distributed under this License is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the
+// License.
+//
+// Authors:
+//    Philipp Wagner <philipp.wagner@tum.de>
+//    Stefan Wallentowitz <stefan@wallentowitz.de>
+
+import dii_package::dii_flit;
+
+module ring_router_gateway_demux
+   #(
+      parameter SUBNET_BITS = 6,
+      parameter LOCAL_SUBNET = 0
+   )(
+      input       clk, rst,
+      input [15:0] id,
+      input dii_flit in_ring, output in_ring_ready,
+      output dii_flit out_local, input out_local_ready,
+      output dii_flit out_ext, input out_ext_ready,
+      output dii_flit out_ring, input out_ring_ready
+   );
+
+   assign out_local.data = in_ring.data;
+   assign out_local.last = in_ring.last;
+   assign out_ext.data = in_ring.data;
+   assign out_ext.last = in_ring.last;
+   assign out_ring.data = in_ring.data;
+   assign out_ring.last = in_ring.last;
+
+   reg         worm;
+   reg         worm_local;
+   reg         worm_ext;
+
+   logic       is_local;
+   logic       is_ext;
+
+   assign is_local = (in_ring.data[15:0] == id);
+   assign is_ext   = (in_ring.data[15:16-SUBNET_BITS] != LOCAL_SUBNET);
+
+   always_ff @(posedge clk) begin
+      if (rst) begin
+         worm <= 0;
+         worm_local <= 1'bx;
+         worm_ext <= 1'bx;
+      end else begin
+         if (!worm) begin
+            worm_local <= is_local;
+            worm_ext <= is_ext;
+            if (in_ring_ready & in_ring.valid & !in_ring.last) begin
+               worm <= 1;
+            end
+         end else begin
+            if (in_ring_ready & in_ring.valid & in_ring.last) begin
+               worm <= 0;
+            end
+         end
+      end
+   end
+
+   logic switch_local;
+   logic switch_ext;
+   assign switch_local = worm ? worm_local : is_local;
+   assign switch_ext = worm ? worm_ext : is_ext;
+
+   always_comb @(*) begin
+      out_local.valid = 1'b0;
+      out_ext.valid = 1'b0;
+      out_ring.valid = 1'b0;
+      in_ring_ready = 1'b0;
+
+      if (switch_local) begin
+         out_local.valid = in_ring.valid;
+         in_ring_ready = out_local_ready;
+      end else if (switch_ext) begin
+         out_ext.valid = in_ring.valid;
+         in_ring_ready = out_ext_ready;
+      end else begin
+         out_ring.valid = in_ring.valid;
+         in_ring_ready = out_ring_ready;
+      end
+   end
+
+endmodule // ring_router_demux

--- a/interconnect/common/ring_router_gateway_mux.sv
+++ b/interconnect/common/ring_router_gateway_mux.sv
@@ -1,0 +1,109 @@
+// Copyright 2016 by the authors
+//
+// Copyright and related rights are licensed under the Solderpad
+// Hardware License, Version 0.51 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a
+// copy of the License at http://solderpad.org/licenses/SHL-0.51.
+// Unless required by applicable law or agreed to in writing,
+// software, hardware and materials distributed under this License is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the
+// License.
+//
+// Authors:
+//    Philipp Wagner <philipp.wagner@tum.de>
+//    Stefan Wallentowitz <stefan@wallentowitz.de>
+
+import dii_package::dii_flit;
+
+module ring_router_gateway_mux
+  (
+   input clk, rst,
+   input dii_flit in_ring, output logic in_ring_ready,
+   input dii_flit in_local, output logic in_local_ready,
+   input dii_flit in_ext, output logic in_ext_ready,
+   output dii_flit out_mux, input out_mux_ready
+   );
+
+   enum         { NOWORM, WORM_LOCAL, WORM_EXT, WORM_RING } state, nxt_state;
+
+   always_ff @(posedge clk) begin
+      if (rst) begin
+         state <= NOWORM;
+      end else begin
+         state <= nxt_state;
+      end
+   end
+
+   always_comb begin
+      nxt_state = state;
+      out_mux.valid = 0;
+      out_mux.data = 'x;
+      out_mux.last = 'x;
+      in_ring_ready = 0;
+      in_local_ready = 0;
+      in_ext_ready = 0;
+
+      case (state)
+        NOWORM: begin
+           if (in_ring.valid) begin
+              in_ring_ready = out_mux_ready;
+              out_mux = in_ring;
+              out_mux.valid = 1'b1;
+
+              if (!in_ring.last) begin
+                 nxt_state = WORM_RING;
+              end
+           end else if (in_local.valid) begin
+              in_local_ready = out_mux_ready;
+              out_mux = in_local;
+              out_mux.valid = 1'b1;
+
+              if (!in_local.last) begin
+                 nxt_state = WORM_LOCAL;
+              end
+           end else if (in_ext.valid) begin
+              in_ext_ready = out_mux_ready;
+              out_mux = in_ext;
+              out_mux.valid = 1'b1;
+
+              if (!in_ext.last) begin
+                 nxt_state = WORM_EXT;
+              end
+           end
+        end // case: NOWORM
+        WORM_RING: begin
+           in_ring_ready = out_mux_ready;
+           out_mux.valid = in_ring.valid;
+           out_mux.last = in_ring.last;
+           out_mux.data = in_ring.data;
+
+           if (out_mux.last & out_mux.valid & out_mux_ready) begin
+              nxt_state = NOWORM;
+           end
+        end
+        WORM_LOCAL: begin
+           in_local_ready = out_mux_ready;
+           out_mux.valid = in_local.valid;
+           out_mux.last = in_local.last;
+           out_mux.data = in_local.data;
+
+           if (out_mux.last & out_mux.valid & out_mux_ready) begin
+              nxt_state = NOWORM;
+           end
+        end
+        WORM_EXT: begin
+           in_ext_ready = out_mux_ready;
+           out_mux.valid = in_ext.valid;
+           out_mux.last = in_ext.last;
+           out_mux.data = in_ext.data;
+
+           if (out_mux.last & out_mux.valid & out_mux_ready) begin
+              nxt_state = NOWORM;
+           end
+        end
+      endcase // case (state)
+   end
+
+endmodule

--- a/interconnect/debug_ring.core
+++ b/interconnect/debug_ring.core
@@ -15,3 +15,6 @@ files =
   common/ring_router.sv
   common/ring_router_mux.sv
   common/ring_router_mux_rr.sv
+  common/ring_router_gateway.sv
+  common/ring_router_gateway_demux.sv
+  common/ring_router_gateway_mux.sv


### PR DESCRIPTION
With subnet support we're moving towards a world where HIM does not
represent the host as address 0 any more. Instead, traffic to the host is
forwarded by a gateway router (similar to a "standard gateway" in IP
networks).

The gateway router added in this commit has an additional output port
which receives all packets not intended for the local subnet (as
specified by the LOCAL_SUBNET parameter).