### PR TITLE
Test has been extended to evaluate debug packets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 /.pydevproject
 /.settings/
 /.svproject
+
+# Unit test temporary files
+DVEfiles/
+ucli.key

--- a/modules/scm/common/osd_scm.sv
+++ b/modules/scm/common/osd_scm.sv
@@ -46,7 +46,7 @@ module osd_scm
 
    osd_regaccess
      #(.MOD_VENDOR(16'h1), .MOD_TYPE(16'h1), .MOD_VERSION(16'h0),
-       .MAX_REG_SIZE(16))
+       .MAX_REG_SIZE(16), .MOD_EVENT_DEST(16'h0))
    u_regaccess(.*,
                .stall ());
 
@@ -69,7 +69,7 @@ module osd_scm
       if (rst) begin
          rst_vector <= 2'b00;
       end else begin
-         if (reg_request & reg_write & (reg_addr == 16'h203))
+         if (reg_request & reg_write & (reg_addr == 16'h204))
             rst_vector <= reg_wdata[1:0];
       end
    end

--- a/modules/scm/test/test_scm.manifest.yaml
+++ b/modules/scm/test/test_scm.manifest.yaml
@@ -1,0 +1,17 @@
+module: test_scm
+
+sources:
+  - ../../../interfaces/common/dii_channel.sv
+  - ../../../blocks/regaccess/common/osd_regaccess.sv
+  - ../common/osd_scm.sv
+
+toplevel: osd_scm
+
+simulators:
+  - vcs
+
+parameters:
+  SYSTEM_VENDOR_ID: 1
+  SYSTEM_DEVICE_ID: 1
+  NUM_MOD: 1
+  MAX_PKT_LEN: 8

--- a/modules/scm/test/test_scm.py
+++ b/modules/scm/test/test_scm.py
@@ -1,0 +1,171 @@
+"""
+    test_scm
+    ~~~~~~~~
+
+    Cocotb-based unit test for the System Control Module (SCM)
+
+    :copyright: Copyright 2017 by the Open SoC Debug team
+    :license: MIT, see LICENSE for details.
+"""
+
+import cocotb
+from cocotb.triggers import Timer
+from cocotb.clock import Clock
+from cocotb.result import TestFailure
+from cocotb.triggers import RisingEdge
+
+from osdtestlib.debug_interconnect import NocDriver, RegAccess, DiPacket
+from osdtestlib.exceptions import *
+
+import random
+
+# DI address of the tested STM module
+MODULE_DI_ADDRESS = 1
+
+# DI address of the sending module
+SENDER_DI_ADDRESS = 0
+
+
+@cocotb.coroutine
+def _init_dut(dut):
+
+    # Setup clock
+    cocotb.fork(Clock(dut.clk, 1000).start())
+
+    # Dump design parameters for debugging
+    dut._log.info("PARAMETER: SYSTEM_VENDOR_ID is %d" %
+                  dut.SYSTEM_VENDOR_ID.value.integer)
+    dut._log.info("PARAMETER: SYSTEM_DEVICE_ID is %d" %
+                  dut.SYSTEM_DEVICE_ID.value.integer)
+    dut._log.info("PARAMETER: NUM_MOD is %d" %
+                  dut.NUM_MOD.value.integer)
+    dut._log.info("PARAMETER: MAX_PKT_LEN is %d" %
+                  dut.MAX_PKT_LEN.value.integer)
+
+    # Reset
+    dut._log.info("Resetting DUT")
+    dut.rst <= 1
+
+    dut.id <= MODULE_DI_ADDRESS
+
+    dut.debug_out_ready <= 1
+
+    for _ in range(2):
+        yield RisingEdge(dut.clk)
+    dut.rst <= 0
+
+@cocotb.coroutine
+def _cpu_reset(dut):
+    """
+    The CPU reset value will be set and reset. The corresponding signal will
+    be observed.
+    """
+
+    access = RegAccess()
+
+    yield access.write_register(dut=dut, dest=MODULE_DI_ADDRESS,
+                                src=SENDER_DI_ADDRESS,
+                                word_width=16,
+                                regaddr=DiPacket.SCM_REG.SYSRST.value,
+                                value=2)
+
+    if dut.cpu_rst != 1:
+        raise TestFailure("CPU reset signal could not be set!")
+
+    yield access.write_register(dut=dut, dest=MODULE_DI_ADDRESS,
+                                src=SENDER_DI_ADDRESS,
+                                word_width=16,
+                                regaddr=DiPacket.SCM_REG.SYSRST.value,
+                                value=0)
+
+    if dut.cpu_rst != 0:
+        raise TestFailure("CPU reset signal could not be reset!")
+
+@cocotb.coroutine
+def _sys_reset(dut):
+    """
+    The system reset value will be set and reset. The corresponding signal
+    will be observed.
+    """
+
+    access = RegAccess()
+
+    yield access.write_register(dut=dut, dest=MODULE_DI_ADDRESS,
+                                src=SENDER_DI_ADDRESS,
+                                word_width=16,
+                                regaddr=DiPacket.SCM_REG.SYSRST.value,
+                                value=1)
+
+    if dut.sys_rst != 1:
+        raise TestFailure("System reset signal could not be set!")
+
+    yield access.write_register(dut=dut, dest=MODULE_DI_ADDRESS,
+                                src=SENDER_DI_ADDRESS,
+                                word_width=16,
+                                regaddr=DiPacket.SCM_REG.SYSRST.value,
+                                value=0)
+
+    if dut.sys_rst != 0:
+        raise TestFailure("System reset signal could not be reset!")
+
+@cocotb.test()
+def test_scm_baseregisters(dut):
+    """
+    Read the 5 additional registers of the SCM and compares the response
+    with the desired value
+    """
+    access = RegAccess()
+    driver = NocDriver()
+
+    yield _init_dut(dut)
+
+    yield access.test_base_registers(dut, MODULE_DI_ADDRESS, SENDER_DI_ADDRESS,
+                                     [1, 1, 0, 1, SENDER_DI_ADDRESS])
+
+@cocotb.test()
+def test_scm_extended(dut):
+    """
+    Read the 5 additional registers of the SCM and compares the response
+    with the desired value
+    """
+    access = RegAccess()
+    driver = NocDriver()
+
+    yield _init_dut(dut)
+
+    dut._log.info("Check contents of SYSTEM_VENDOR_ID")
+    yield access.assert_reg_value(dut, MODULE_DI_ADDRESS, SENDER_DI_ADDRESS,
+                                  DiPacket.SCM_REG.SYSTEM_VENDOR_ID.value, 1)
+
+    dut._log.info("Check contents of SYSTEM_DEVICE_ID")
+    yield access.assert_reg_value(dut, MODULE_DI_ADDRESS, SENDER_DI_ADDRESS,
+                                  DiPacket.SCM_REG.SYSTEM_DEVICE_ID.value, 1)
+
+    dut._log.info("Check contents of NUM_MOD")
+    yield access.assert_reg_value(dut, MODULE_DI_ADDRESS, SENDER_DI_ADDRESS,
+                                  DiPacket.SCM_REG.NUM_MOD.value, 1)
+
+    dut._log.info("Check contents of MAX_PKT_LEN")
+    yield access.assert_reg_value(dut, MODULE_DI_ADDRESS, SENDER_DI_ADDRESS,
+                                  DiPacket.SCM_REG.MAX_PKT_LEN.value, 8)
+
+    dut._log.info("Check contents of SYSRST")
+    yield access.assert_reg_value(dut, MODULE_DI_ADDRESS, SENDER_DI_ADDRESS,
+                                  DiPacket.SCM_REG.SYSRST.value, 0)
+
+
+@cocotb.test()
+def test_scm_reset(dut):
+    """
+    Activates and deactivates the CPU and system reset by writing into the
+    system reset register. The sys_rst and cpu_rst ports are observed to
+    verify the correct reaction.
+    """
+
+    yield _init_dut(dut)
+
+
+    yield _cpu_reset(dut)
+
+    yield _sys_reset(dut)
+


### PR DESCRIPTION
After verifying that the base registers contain the correct values,
the test now also generates stimuli on the "trace_id" and the "trace_value" signals. 
A new class "TraceGenerator" has been created which takes care of this.

As a result the STM will generate a debug event packet which is read and evaluated.
Currently the test considers debug events generated using the old packet format.
The evaluation is done in a new method of the "EvalUtility" class.

Minor changes and adjustments to the debug interconnect file have been made.